### PR TITLE
Updated model and create_url method to simplify relative URL requests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "restsession"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="Palmer Sample", email="palmer@palmersample.net" },
 ]

--- a/restsession/models.py
+++ b/restsession/models.py
@@ -13,7 +13,8 @@ from typing import (Optional,
 from pydantic import (BaseModel,
                       ConfigDict,
                       AfterValidator,
-                      AnyHttpUrl)
+                      AnyHttpUrl,
+                      field_validator)
 from requests.auth import AuthBase
 from .defaults import SESSION_DEFAULTS
 
@@ -50,3 +51,11 @@ class SessionParamModel(BaseModel):
     safe_arguments: bool = SESSION_DEFAULTS["safe_arguments"]
     timeout: Union[float, tuple[float, float]] = SESSION_DEFAULTS["timeout"]
     tls_verify: bool = SESSION_DEFAULTS["verify"]
+
+    @field_validator("base_url")
+    @classmethod
+    def base_url_ends_with_slash(cls, v: Optional[AnyUrlString]) -> Optional[AnyUrlString]:
+        if v is not None:
+            if not v.endswith("/"):
+                v = f"{v}/"
+        return v


### PR DESCRIPTION
Identified an issue when attempting to call a relative URL without properly creating the path component (missing / or ./ before the relative URL)

Updated create_url method to generate a valid relative URL before calling the urllib.parse.urljoin. Also updated the pydantic model for base_url to ensure a trailing slash or added if not present when the session is created.

Updated test "test_base_url_bad_urljoin" so it now expects a response of OK instead of an exception.