### PR TITLE
Update permissions on release stage.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       name: release
       url: https://pypi.org/p/restsession
     permissions:
-      id-token: write
+      contents: write
 
     steps:
       - name: Load distribution cache


### PR DESCRIPTION
Wrong permissions were set on the release step. Updated id-token to content