### PR TITLE
Add path restrictions to the CI and release workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
-name: Build all packages and dependencies
+---
+name: Build
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - src/**
+      - tests/**
+      - pyproject.toml
+      - poetry.lock
 
 jobs:
   setup:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,5 @@
-name: Lint all source files
+---
+name: Linting
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,15 @@
+---
 name: PyPi Release
 
 on:
   pull_request_target:
     types:
       - closed
+    paths:
+      - src/**
+      - tests/**
+      - pyproject.toml
+      - poetry.lock
 
 jobs:
   setup:
@@ -45,8 +51,12 @@ jobs:
         run: |
           ls -la dist
 
-      - name: Upload wheel to PyPi Production
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Check version for RC status
+        id: release-check
+        run: |
+          if [[ "${{ needs.setup.outputs.project-version }}" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+            echo "pypi-release=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Tag this commit
         id: create_tag
@@ -55,4 +65,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{ github.sha }}
           tag: ${{ needs.setup.outputs.project-version }}
-          artifacts: "dist/*.whl"
+          artifacts: "dist/*.whl,dist/*.tar.gz"
+
+      - name: Upload wheel to PyPi Production
+        if: >-
+          ${{
+            steps.release-check.outputs.pypi-release == 'true' && 
+            needs.setup.outputs.local-version-higher == 'true'
+          }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,3 +1,4 @@
+---
 name: Setup
 on:
   workflow_call:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Test
 on:
   workflow_call:


### PR DESCRIPTION
* Add conditional for PyPi production upload - do not upload release candidates.

* Change order of PyPi push - perform after the release is tagged to preserve artifacts in the event of PyPi push failure